### PR TITLE
Update check_rng_file to clarify that it's ensuring contents are as expected

### DIFF
--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -2,8 +2,6 @@
 # See LICENSE file for licensing details.
 """Module that handles Pollen charm's state."""
 
-from pathlib import Path
-
 from pydantic import BaseModel, Extra
 
 HTTP_PORT = "443"

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -35,11 +35,6 @@ class CharmState:
             hostname: hostname to build the website property
         """
         self._hostname = hostname
-        file = Path("/etc/default/rng-tools-debian")
-        # The file already has this line commented by default,
-        # so we should check if it appears in the file twice (commented and actually written).
-        # The file needs the commented code header so the rngd service does not fail.
-        self.rng_tools_file = "" if not file.exists() else file.read_text(encoding="utf-8")
 
     @property
     def website(self) -> WebsiteModel:

--- a/src/pollen.py
+++ b/src/pollen.py
@@ -57,7 +57,7 @@ class PollenService:
             try:
                 apt.update()
                 apt.add_package("rng-tools5")
-                self.ensure_rng_file_contents(charm_state)
+                self.ensure_rng_file_contents()
                 systemd.service_restart("rngd.service")
             except systemd.SystemdError as exc:
                 raise ConfigurationWriteError from exc
@@ -74,12 +74,8 @@ class PollenService:
         pollen = cache[SNAP_NAME]
         pollen.stop()
 
-    def ensure_rng_file_contents(self, charm_state):
-        """Ensure the rng file contents are as expected.
-
-        Args:
-            charm_state: Pollen charm's CharmState instance.
-        """
+    def ensure_rng_file_contents(self):
+        """Ensure the rng file contents are as expected."""
         file = Path("/etc/default/rng-tools-debian")
         if file.read_text(encoding="utf-8") != RNG_FILE_VALUE:
             file.write_text(RNG_FILE_VALUE, encoding="utf-8")

--- a/src/pollen.py
+++ b/src/pollen.py
@@ -77,5 +77,5 @@ class PollenService:
     def ensure_rng_file_contents(self):
         """Ensure the rng file contents are as expected."""
         file = Path("/etc/default/rng-tools-debian")
-        if file.read_text(encoding="utf-8") != RNG_FILE_VALUE:
+        if not file.exists() or file.read_text(encoding="utf-8") != RNG_FILE_VALUE:
             file.write_text(RNG_FILE_VALUE, encoding="utf-8")


### PR DESCRIPTION
Previously this function was named `check_rng_file`, but renaming it clarifies that it's actually ensuring the contents.

Also previously the comment suggested that a commented version of the string was required, but this wasn't true. Because we're doing `file.write_text()` the only contents of that file are what we're writing, and it no longer includes the commented value.

Here's a short juju session showing this:

```
mthaddon@finistere:~$ juju status
Model    Controller           Cloud/Region         Version  SLA          Timestamp
default  localhost-localhost  localhost/localhost  2.9.43   unsupported  11:19:01+02:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
pollen           active      1  pollen  edge       1  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
pollen/0*  active    idle   0        10.46.16.169

Machine  State    Address       Inst id        Series  AZ  Message
0        started  10.46.16.169  juju-14da31-0  jammy       Running

mthaddon@finistere:~$ juju ssh 0 -- cat /etc/default/rng-tools-debian
RNGDOPTIONS="--fill-watermark=90% --feed-interval=1"Connection to 10.46.16.169 closed.
mthaddon@finistere:~$ pollinate -i -s http://10.46.16.169:80 -t
<13>Jul 10 11:23:57 pollinate[904367]: client sent challenge to [http://10.46.16.169:80]
<13>Jul 10 11:23:57 pollinate[904367]: client verified challenge/response with [http://10.46.16.169:80]
_'"�����g�k�N�1w�<�U�^oM����cօ%Y�gD�����9�X�[g���)O^�<13>Jul 10 11:23:57 pollinate[904367]: client hashed response from [http://10.46.16.169:80]
<13>Jul 10 11:23:57 pollinate[904367]: client successfully seeded [-]
```