### PR TITLE
ISD-913: Fix HTTP port

### DIFF
--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -4,7 +4,7 @@
 
 from pydantic import BaseModel, Extra
 
-HTTP_PORT = "443"
+HTTP_PORT = 80
 
 
 class WebsiteModel(BaseModel, extra=Extra.forbid):
@@ -40,7 +40,7 @@ class CharmState:
 
         Returns: a WebsiteDict object to be used by the website relation.
         """
-        website_data = {"hostname": format(self._hostname), "port": HTTP_PORT}
+        website_data = {"hostname": format(self._hostname), "port": str(HTTP_PORT)}
         website_model = WebsiteModel(**website_data)
         return website_model
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -155,4 +155,4 @@ class TestCharm(unittest.TestCase):
 
     def test_charm_state_website_property(self):
         charm_state = CharmState("hostname")
-        self.assertEqual(charm_state.website, {"hostname": "hostname", "port": HTTP_PORT})
+        self.assertEqual(charm_state.website, {"hostname": "hostname", "port": str(HTTP_PORT)})


### PR DESCRIPTION
Currently, the http port is set to 443. This is wrong because Pollen needs to use port 80 to communicate with the proxy, and then the proxy will use HTTPS on its side of things. Also, the port should be an integer according to ISD-913.