### PR TITLE
Add a comment explaining the snap location, which currently points to a personal namespace

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,3 +9,4 @@ jobs:
     secrets: inherit
     with:
       provider: lxd
+      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,4 +9,3 @@ jobs:
     secrets: inherit
     with:
       provider: lxd
-      tmate-debug: true

--- a/src/pollen.py
+++ b/src/pollen.py
@@ -13,6 +13,7 @@ from charms.operator_libs_linux.v2 import snap
 from charm_state import HTTP_PORT
 from exceptions import ConfigurationWriteError, InstallError
 
+# This will be changed to 'pollen' once the upstream snap location is updated.
 SNAP_NAME = "gtrkiller-pollen"
 RNG_FILE_VALUE = 'RNGDOPTIONS="--fill-watermark=90% --feed-interval=1"'
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# noqa: D104
+"""Tests for the pollen operator."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.  # noqa: D104
 # See LICENSE file for licensing details.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,4 @@
-# Copyright 2023 Canonical Ltd.  # noqa: D104
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+
+# noqa: D104

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Fixtures for Indico charm tests."""
+
+
+def pytest_addoption(parser):
+    """Parse additional pytest options.
+
+    Args:
+        parser: Pytest parser.
+    """
+    parser.addoption("--charm-file", action="store")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,4 +10,5 @@ def pytest_addoption(parser):
     Args:
         parser: Pytest parser.
     """
+    raise NotImplementedError
     parser.addoption("--charm-file", action="store")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,5 +10,4 @@ def pytest_addoption(parser):
     Args:
         parser: Pytest parser.
     """
-    raise NotImplementedError
     parser.addoption("--charm-file", action="store")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Fixtures for Indico charm tests."""
+"""Fixtures for Pollen charm tests."""
 
 
 def pytest_addoption(parser):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# noqa: D104

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# noqa: D104
+"""Integration tests for the Pollen operator."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from typing import Any, Awaitable, Callable
 import pytest_asyncio
 import yaml
 from ops.model import ActiveStatus
-from pytest import fixture
+from pytest import Config, fixture
 from pytest_operator.plugin import OpsTest
 
 
@@ -52,6 +52,7 @@ def run_action(ops_test: OpsTest) -> Callable[[str, str], Awaitable[Any]]:
 async def app(
     ops_test: OpsTest,
     app_name: str,
+    pytestconfig: Config,
     run_action,
 ):
     """Pollen charm used for integration testing.
@@ -73,9 +74,9 @@ async def app(
     )
     await ops_test.model.wait_for_idle(status="active")
 
-    app_charm = await ops_test.build_charm(".")
+    charm = pytestconfig.getoption("--charm-file")
     application = await ops_test.model.deploy(
-        app_charm,
+        f"./{charm}",
         application_name=app_name,
         series="jammy",
     )

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# noqa: D104

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# noqa: D104
+"""Unit tests for the Pollen operator."""

--- a/tox.ini
+++ b/tox.ini
@@ -96,4 +96,4 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/tests/integration/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest --trace --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==2.9.42.4
+    juju==2.9.44.0
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/tests/integration/requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -96,4 +96,4 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/tests/integration/requirements.txt
 commands =
-    pytest --trace --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
A PR has been proposed against the upstream pollen code adding a snap. Once that's merged and the new snap is published as `pollen` this will be updated, so include a comment explaining why we're using a personal snap in the meantime.

Also update to use pre-built charm file in integration tests. Also updated pylibjuju to use a version that matches the Juju version in CI.