### PR TITLE
Update the README to conform to guidelines, correct relation-changed docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,14 @@
-A Juju charm deploying Pollen on a machine. Pollen is a scalable,
-high performance, free software (AGPL) web server, that provides small
-strings of entropy, over TLS-encrypted HTTPS or clear text HTTP connections.
-You might think of this as 'Entropy-as-a-Service'.
+# Pollen
 
-Pollinate is a free software (GPLv3) script that retrieves entropy from one
-or more Pollen servers and seeds the local Pseudo Random Number Generator (PRNG).
-You might think of this as PRNG-seeding via Entropy-as-a-Service.
+More information: https://charmhub.io/pollen
 
-This charm simplifies initial deployment and operations of Pollen
-on a machine, such as scaling the number of instances and clustering and more.
+Pollen is a scalable, high performance, free software (AGPL) web server, that
+provides small strings of entropy, over TLS-encrypted HTTPS or clear text HTTP
+connections. You might think of this as 'Entropy-as-a-Service'. This charm
+deploys a Pollen server.
 
-As such, the charm makes it easy for those looking to take control of their own
-entropy generation whilst keeping operations simple.
+## Other resources
 
-For DevOps or SRE teams this charm will make operating Pollen simple and
-straightforward through Juju’s clean interface. It will allow easy deployment
-into multiple environments for testing of changes, and supports scaling out for
-enterprise deployments.
+- [The Pollen source repository](https://github.com/canonical/pollen)
 
-## Project and community
-
-Pollen is an open-source project that welcomes community contributions, suggestions, fixes and constructive feedback.
-- [Read our Code of Conduct](https://ubuntu.com/community/code-of-conduct)
-- [Join the Discourse forum](https://discourse.charmhub.io/tag/pollen)
-- [Discuss on the Mattermost chat service](https://chat.charmhub.io/charmhub/channels/charm-dev)
-- Contribute and report bugs to [the Pollen operator](https://github.com/canonical/pollen-operator)
-
-## Contributing to this documentation
-
-Documentation is an important part of this project, and we take the same open-source approach to the documentation as the code. As such, we welcome community contributions, suggestions and constructive feedback on our documentation. Our documentation is hosted on the [Charmhub forum](https://discourse.charmhub.io/) to enable easy collaboration. Please use the "Help us improve this documentation" links on each documentation page to either directly change something you see that's wrong, or ask a question, or make a suggestion about a potential change via the comments section.
-
-If there's a particular area of documentation that you'd like to see that's missing, please [file a bug](https://github.com/canonical/pollen-operator/issues).
+- See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-# Learn more at: https://juju.is/docs/sdk
 
 """Charm for Pollen on a machine."""
 
@@ -51,7 +49,7 @@ class PollenOperatorCharm(ops.CharmBase):
         """Handle website-relation-changed.
 
         Args:
-            event: Event triggering the website relation joined handler.
+            event: Event triggering the website relation changed handler.
         """
         event.relation.data[self.unit].update(self._charm_state.website)
 


### PR DESCRIPTION
This follows the guidelines for the README per https://github.com/canonical/charmcraft/blob/main/charmcraft/templates/init-simple/README.md.j2.

Also some minor updates to `src/charm.py` to remove template comment and correct the docstring for a relation-changed handler.