### PR TITLE
Update postrotate command

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,3 +9,4 @@ jobs:
     secrets: inherit
     with:
       provider: lxd
+      juju-channel: 3.1/stable

--- a/files/logrotate.conf
+++ b/files/logrotate.conf
@@ -13,6 +13,6 @@
         notifempty
         sharedscripts
         postrotate
-                reload rsyslog >/dev/null 2>&1 || true
+                invoke-rc.d rsyslog rotate >/dev/null
         endscript
 }

--- a/files/rsyslog.conf
+++ b/files/rsyslog.conf
@@ -4,4 +4,4 @@
 $FileCreateMode 0644
 
 :syslogtag, startswith, "pollen" /var/log/pollen/pollen.log
-& ~
+& stop

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,8 +48,9 @@ async def test_prom_metrics_are_up(app: Application):
     pollen_unit = app.units[0]
     # Send request to /metrics for each target and check the response
     cmd = f"curl http://localhost:{METRICS_PORT}/metrics"
-    action = await pollen_unit.run(cmd)
-    code = action.results.get("Code")
+    action_cmd = await pollen_unit.run(cmd)
+    action = await action_cmd.wait()
+    code = action.results.get("return-code")
     stdout = action.results.get("Stdout")
     stderr = action.results.get("Stderr")
-    assert code == "0", f"{cmd} failed ({code}): {stderr or stdout}"
+    assert code == 0, f"{cmd} failed ({code}): {stderr or stdout}"

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==2.9.44.0
+    juju==3.1.2.0
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/tests/integration/requirements.txt
 commands =


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Pollen Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Update the logrotate postrotate command to avoid issues related to https://github.com/rsyslog/rsyslog/issues/1506

### Rationale

The current postrotate command can lead to the pollen unit servicing requests but not logging anything silently.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

Changed Juju to 3.1, given that the charm is new and it can stay up to date with newer versions of Juju without any significant changes to the tests.

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
